### PR TITLE
Use `docker push` to publish images to a registry

### DIFF
--- a/2.hello-kubernetes/README.md
+++ b/2.hello-kubernetes/README.md
@@ -213,6 +213,6 @@ Now that you're successfully working with Dapr, you probably want to update the 
 2. Navigate to the directory of the app you want to build a new image for.
 3. Run `docker build -t <YOUR_IMAGE_NAME> . `. You can name your image whatever you like. If you're planning on hosting it on docker hub, then it should start with `<YOUR_DOCKERHUB_USERNAME>/`.
 4. Once your image has built you can see it on your machines by running `docker images`.
-5. To publish your docker image to docker hub (or another registry), first login: `docker login`. Then run`docker publish <YOUR IMAGE NAME>`.
+5. To publish your docker image to docker hub (or another registry), first login: `docker login`. Then run`docker push <YOUR IMAGE NAME>`.
 6. Update your .yaml file to reflect the new image name.
 7. Deploy your updated Dapr enabled app: `kubectl apply -f <YOUR APP NAME>.yaml`.


### PR DESCRIPTION
# Description

Updated the README to use the correct `docker push` command to publish Docker images to a registry. The previously command `docker publish` does not exist.

## Issue reference

Please reference the issue this PR will close: #_[101]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [N/A] The sample code compiles correctly
* [N/A] You've tested new builds of the sample if you changed sample code
* [X] You've updated the sample's README if necessary
